### PR TITLE
add skeleton code to modify user info based on "delius" scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 /build/
 !gradle/wrapper/gradle-wrapper.jar
+.DS_Store
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build/
 !gradle/wrapper/gradle-wrapper.jar
 .DS_Store
+.run/
 
 ### STS ###
 .apt_generated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
 
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-webflux")
+
   implementation("javax.annotation:javax.annotation-api:1.3.2")
   implementation("javax.xml.bind:jaxb-api:2.3.1")
   implementation("com.sun.xml.bind:jaxb-impl:2.3.3")

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/azure/AzureUserPersonDetails.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/azure/AzureUserPersonDetails.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.oauth2server.azure
+
+import org.springframework.security.core.GrantedAuthority
+import uk.gov.justice.digital.hmpps.oauth2server.auth.model.Person
+import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource
+import uk.gov.justice.digital.hmpps.oauth2server.security.UserPersonDetails
+
+data class AzureUserPersonDetails(private val authorities: MutableCollection<GrantedAuthority>,
+                                  private val enabled: Boolean,
+                                  private val username: String,
+                                  private val firstName: String,
+                                  val surname: String,
+                                  val email: String,
+                                  private val credentialsNonExpired: Boolean,
+                                  private val password: String,
+                                  private val accountNonExpired: Boolean,
+                                  private val accountNonLocked: Boolean) : UserPersonDetails {
+    override fun getAuthorities(): Collection<GrantedAuthority?> = authorities
+
+    override fun isEnabled(): Boolean = enabled
+
+    override fun getUsername(): String = username
+
+    override fun isCredentialsNonExpired(): Boolean = credentialsNonExpired
+
+    override fun getPassword(): String = password
+
+    override fun isAccountNonExpired(): Boolean = accountNonExpired
+
+    override fun isAccountNonLocked(): Boolean = accountNonLocked
+
+    override fun getUserId(): String = username
+
+    override fun getName(): String = "$firstName $surname"
+
+    override fun getFirstName(): String = firstName
+
+    override fun getAuthSource(): String? = AuthSource.azure.name
+
+    override fun eraseCredentials() {
+    }
+
+    override fun toUser(): User? {
+        return User.builder()
+                .username(username)
+                .source(AuthSource.azure)
+                .email(email)
+                .verified(true)
+                .enabled(enabled)
+                .person(Person(firstName, surname))
+                .build()
+    }
+
+    override fun isAdmin(): Boolean = false
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/azure/service/AzureUserDetailsService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/azure/service/AzureUserDetailsService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.oauth2server.azure.service
+
+import org.springframework.security.core.userdetails.AuthenticationUserDetailsService
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.oauth2server.azure.AzureUserPersonDetails
+
+@Service("azureUserDetailsService")
+class AzureUserDetailsService(private val azureUserService: AzureUserService):
+        UserDetailsService, AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {
+    override fun loadUserByUsername(username: String?): AzureUserPersonDetails {
+        return azureUserService.getAzureUserByUsername(username).orElseThrow { UsernameNotFoundException(username) }
+    }
+
+    override fun loadUserDetails(token: PreAuthenticatedAuthenticationToken): UserDetails = loadUserByUsername(token.name)
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/azure/service/AzureUserService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/azure/service/AzureUserService.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.oauth2server.azure.service
+
+import lombok.extern.slf4j.Slf4j
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.oauth2server.auth.repository.UserRepository
+import uk.gov.justice.digital.hmpps.oauth2server.azure.AzureUserPersonDetails
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource
+import java.util.*
+
+@Slf4j
+@Service
+class AzureUserService(private val userRepository: UserRepository) {
+
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    fun getAzureUserByUsername(username: String?): Optional<AzureUserPersonDetails> {
+        val user = userRepository.findByUsernameAndSource(username, AuthSource.azure)
+
+        if (user.isPresent) {
+            return Optional.of(AzureUserPersonDetails(Collections.emptyList(),
+                true,
+                user.get().username,
+                user.get().person.firstName,
+                user.get().person.lastName,
+                user.get().email,
+                credentialsNonExpired = true,
+                password = "",
+                accountNonExpired = true,
+                accountNonLocked = true))
+        }
+        return Optional.empty()
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfiguration.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfiguration.java
@@ -15,6 +15,15 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.provider.endpoint.DefaultRedirectResolver;
 import org.springframework.security.oauth2.provider.endpoint.RedirectResolver;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
@@ -22,6 +31,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.reactive.function.client.WebClient;
 import uk.gov.justice.digital.hmpps.oauth2server.resource.ClearAllSessionsLogoutHandler;
 import uk.gov.justice.digital.hmpps.oauth2server.resource.LoggingAccessDeniedHandler;
 import uk.gov.justice.digital.hmpps.oauth2server.resource.RedirectingLogoutSuccessHandler;
@@ -30,7 +40,11 @@ import uk.gov.justice.digital.hmpps.oauth2server.security.DeliusAuthenticationPr
 import uk.gov.justice.digital.hmpps.oauth2server.security.JwtAuthenticationSuccessHandler;
 import uk.gov.justice.digital.hmpps.oauth2server.security.JwtCookieAuthenticationFilter;
 import uk.gov.justice.digital.hmpps.oauth2server.security.NomisAuthenticationProvider;
+import uk.gov.justice.digital.hmpps.oauth2server.security.OidcJwtAuthenticationSuccessHandler;
 import uk.gov.justice.digital.hmpps.oauth2server.security.UserStateAuthenticationFailureHandler;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @Order(4)
@@ -38,6 +52,7 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
 
     private final LoggingAccessDeniedHandler accessDeniedHandler;
     private final RedirectingLogoutSuccessHandler logoutSuccessHandler;
+    private final OidcJwtAuthenticationSuccessHandler oidcJwtAuthenticationSuccessHandler;
     private final JwtAuthenticationSuccessHandler jwtAuthenticationSuccessHandler;
     private final JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter;
     private final String jwtCookieName;
@@ -49,14 +64,17 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
     private final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> nomisUserDetailsService;
     private final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> authUserDetailsService;
     private final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> deliusUserDetailsService;
+    private final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> azureUserDetailsService;
     private final ClearAllSessionsLogoutHandler clearAllSessionsLogoutHandler;
 
     @Autowired
     public AuthenticationManagerConfiguration(@Qualifier("nomisUserDetailsService") final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> nomisUserDetailsService,
                                               @Qualifier("authUserDetailsService") final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> authUserDetailsService,
                                               @Qualifier("deliusUserDetailsService") final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> deliusUserDetailsService,
+                                              @Qualifier("azureUserDetailsService") final AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> azureUserDetailsService,
                                               final LoggingAccessDeniedHandler accessDeniedHandler,
                                               final RedirectingLogoutSuccessHandler logoutSuccessHandler,
+                                              final OidcJwtAuthenticationSuccessHandler oidcJwtAuthenticationSuccessHandler,
                                               final JwtAuthenticationSuccessHandler jwtAuthenticationSuccessHandler,
                                               final JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter,
                                               @Value("${jwt.cookie.name}") final String jwtCookieName,
@@ -68,8 +86,10 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
                                               final ClearAllSessionsLogoutHandler clearAllSessionsLogoutHandler) {
         this.nomisUserDetailsService = nomisUserDetailsService;
         this.authUserDetailsService = authUserDetailsService;
+        this.azureUserDetailsService = azureUserDetailsService;
         this.accessDeniedHandler = accessDeniedHandler;
         this.logoutSuccessHandler = logoutSuccessHandler;
+        this.oidcJwtAuthenticationSuccessHandler = oidcJwtAuthenticationSuccessHandler;
         this.jwtAuthenticationSuccessHandler = jwtAuthenticationSuccessHandler;
         this.jwtCookieAuthenticationFilter = jwtCookieAuthenticationFilter;
         this.jwtCookieName = jwtCookieName;
@@ -99,8 +119,14 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
                 .antMatchers(HttpMethod.POST, "/login").permitAll()
                 .antMatchers("/ui/**").access("isAuthenticated() and @authIpSecurity.check(request)")
                 .anyRequest().authenticated()
-
             .and()
+                .oauth2Login()
+                        .userInfoEndpoint(userInfo -> userInfo.oidcUserService(this.oidcUserService()))
+                        .loginPage("/login")
+                        .successHandler(oidcJwtAuthenticationSuccessHandler)
+                        .failureHandler(userStateAuthenticationFailureHandler)
+                        .permitAll()
+                .and()
                 .formLogin()
                 .loginPage("/login")
                 .successHandler(jwtAuthenticationSuccessHandler)
@@ -126,6 +152,33 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
 
                 .requestCache().requestCache(cookieRequestCache);
         // @formatter:on
+    }
+
+    /**
+     * Custom User Service for the Azure OIDC integration. Spring expects to get the username from the userinfo endpoint,
+     * unfortunately the Azure endpoint doesn't return the field we need - i.e. preferred_username. Therefore the username field is set
+     * to sub in the configuration, and modified here once the token and userinfo attributes are merged.
+     *
+     * Also capitalises the username so the Auth database lookups work.
+     */
+    @Bean
+    public OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
+        final OidcUserService delegate = new OidcUserService();
+
+        return (userRequest) -> {
+            // Delegate to the default implementation for loading a user
+            OidcUser oidcUser = delegate.loadUser(userRequest);
+
+            // Now we have the claims from the id token and the userinfo response combined, we can set the preferred_username field to be the name source
+            var idToken = oidcUser.getIdToken();
+
+            Map<String,Object> newClaims = new HashMap<>(idToken.getClaims());
+            newClaims.replace("preferred_username", ((String)newClaims.get("preferred_username")).toUpperCase());
+
+            var oidcIdToken = new OidcIdToken(idToken.getTokenValue(),idToken.getIssuedAt(), idToken.getExpiresAt(), newClaims);
+
+            return new DefaultOidcUser(oidcUser.getAuthorities(), oidcIdToken, oidcUser.getUserInfo(), "preferred_username");
+        };
     }
 
     @Override
@@ -161,6 +214,7 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
         auth.authenticationProvider(deliusAuthenticationProvider);
         auth.authenticationProvider(preAuthProvider(authUserDetailsService));
         auth.authenticationProvider(preAuthProvider(nomisUserDetailsService));
+        auth.authenticationProvider(preAuthProvider(azureUserDetailsService));
         auth.authenticationProvider(preAuthProvider(deliusUserDetailsService));
     }
 
@@ -189,5 +243,15 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
         final var redirectResolver = new DefaultRedirectResolver();
         redirectResolver.setMatchSubdomains(matchSubdomains);
         return redirectResolver;
+    }
+
+    @Bean
+    WebClient webClient(ClientRegistrationRepository clientRegistrationRepository,
+                        OAuth2AuthorizedClientRepository authorizedClientRepository) {
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 =
+                new ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrationRepository,
+                        authorizedClientRepository);
+        oauth2.setDefaultOAuth2AuthorizedClient(true);
+        return WebClient.builder().apply(oauth2.oauth2Configuration()).build();
     }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/delius/model/UserDetails.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/delius/model/UserDetails.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class UserDetails @JsonCreator constructor(@JsonProperty("userId") val userId: String,
+                                                @JsonProperty("username") val username: String,
                                                 @JsonProperty("surname") val surname: String,
                                                 @JsonProperty("firstName") val firstName: String,
                                                 @JsonProperty("email") val email: String,

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserController.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserController.java
@@ -72,16 +72,11 @@ public class UserController {
             @ApiResponse(code = 200, message = "OK", response = EmailAddress.class),
             @ApiResponse(code = 204, message = "No content.  No verified email address found for user"),
             @ApiResponse(code = 404, message = "User not found.  The user doesn't exist in auth so could have never logged in", response = ErrorDetail.class)})
-    public ResponseEntity<Object> getUserEmail(@ApiParam(value = "The username of the user.", required = true) @PathVariable final String username) {
-        final var user = userService.findUser(username);
-
-        if (user.isEmpty()) {
-            return notFoundResponse(username);
-        }
-
-        final var email = user.get();
-
-        return email.isVerified() ? ResponseEntity.ok(EmailAddress.fromUser(email)) : ResponseEntity.noContent().build();
+    public ResponseEntity<?> getUserEmail(@ApiParam(value = "The username of the user.", required = true) @PathVariable final String username) {
+        return userService
+                .getOrCreateUser(username)
+                .map(email -> email.isVerified() ? ResponseEntity.ok(EmailAddress.fromUser(email)) : ResponseEntity.noContent().build())
+                .orElseGet(() -> notFoundResponse(username));
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/AuthSource.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/AuthSource.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Optional;
 
 public enum AuthSource {
-    nomis, auth, delius, none;
+    nomis, auth, delius, azure, none;
 
     @JsonValue
     public String getSource() {

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/AuthSource.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/AuthSource.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Optional;
 
 public enum AuthSource {
-    nomis, auth, delius, azure, none;
+    auth, azure, delius, nomis, none;
 
     @JsonValue
     public String getSource() {

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/JwtAuthenticationHelper.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/JwtAuthenticationHelper.java
@@ -13,6 +13,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
 import org.springframework.stereotype.Component;
 
@@ -47,9 +49,25 @@ public class JwtAuthenticationHelper {
     }
 
     String createJwt(final Authentication authentication) {
-        return createJwtWithId(authentication, UUID.randomUUID().toString());
+        return authentication instanceof OAuth2AuthenticationToken ?
+                createJwtWithIdFromOidcAuthentication((OAuth2AuthenticationToken)authentication, UUID.randomUUID().toString())
+                : createJwtWithId(authentication, UUID.randomUUID().toString());
     }
 
+    String createJwtWithIdFromOidcAuthentication(final OAuth2AuthenticationToken authentication, final String jwtId) {
+        final var userDetails = (DefaultOidcUser) authentication.getPrincipal();
+        final var username = userDetails.getName();
+        log.debug("Creating jwt cookie for user {}", username);
+        final var authorities = Optional.ofNullable(authentication.getAuthorities()).orElse(Collections.emptyList());
+        final var authoritiesAsString = authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(","));
+        return Jwts.builder()
+                .setId(jwtId)
+                .setSubject(username)
+                .addClaims(Map.of("authorities", authoritiesAsString, "name", userDetails.getFullName(), "auth_source", "azure", "user_id", userDetails.getPreferredUsername()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiryTime.toMillis()))
+                .signWith(SignatureAlgorithm.RS256, keyPair.getPrivate())
+                .compact();
+    }
 
     String createJwtWithId(final Authentication authentication, final String jwtId) {
         final var userDetails = (UserPersonDetails) authentication.getPrincipal();

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/OidcJwtAuthenticationSuccessHandler.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/OidcJwtAuthenticationSuccessHandler.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.oauth2server.security
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import uk.gov.justice.digital.hmpps.oauth2server.azure.AzureUserPersonDetails
+import uk.gov.justice.digital.hmpps.oauth2server.config.CookieRequestCache
+import uk.gov.justice.digital.hmpps.oauth2server.verify.VerifyEmailService
+import java.io.IOException
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class OidcJwtAuthenticationSuccessHandler(jwtCookieHelper: JwtCookieHelper?,
+                                          jwtAuthenticationHelper: JwtAuthenticationHelper?,
+                                          cookieRequestCache: CookieRequestCache?,
+                                          verifyEmailService: VerifyEmailService?,
+                                          @Qualifier("tokenVerificationApiRestTemplate") restTemplate: RestTemplate?,
+                                          @Value("\${tokenverification.enabled:false}") tokenVerificationEnabled: Boolean,
+                                          private val userRetriesService: UserRetriesService) : JwtAuthenticationSuccessHandler(jwtCookieHelper, jwtAuthenticationHelper, cookieRequestCache, verifyEmailService, restTemplate, tokenVerificationEnabled) {
+    @Throws(IOException::class, ServletException::class)
+    override fun onAuthenticationSuccess(request: HttpServletRequest, response: HttpServletResponse,
+                                         authentication: Authentication) {
+        val authenticationResult = authentication as OAuth2AuthenticationToken
+        val principal = authenticationResult.principal as DefaultOidcUser
+
+        // Enables compatibility with dev and production Azure configurations
+        val givenName = when {
+            principal.givenName != null -> principal.givenName
+            principal.fullName.split(",").size == 2 -> principal.fullName.split(",")[1]
+            else -> ""
+        }
+
+        val familyName = when {
+            principal.familyName != null -> principal.familyName
+            principal.fullName.split(",").size == 2 -> principal.fullName.split(",")[0]
+            else -> ""
+        }
+
+        val upd = AzureUserPersonDetails(ArrayList(),
+                true,
+                principal.name,
+                givenName,
+                familyName,
+                principal.preferredUsername,
+                true,
+                "",
+                accountNonExpired = true,
+                accountNonLocked = true)
+
+        userRetriesService.resetRetriesAndRecordLogin(upd)
+        super.onAuthenticationSuccess(request, response, authentication)
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserService.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User
 import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User.EmailType
 import uk.gov.justice.digital.hmpps.oauth2server.auth.repository.UserRepository
+import uk.gov.justice.digital.hmpps.oauth2server.azure.service.AzureUserService
 import uk.gov.justice.digital.hmpps.oauth2server.delius.service.DeliusUserService
 import uk.gov.justice.digital.hmpps.oauth2server.maintain.AuthUserService
 import uk.gov.justice.digital.hmpps.oauth2server.verify.VerifyEmailService
@@ -19,6 +20,7 @@ import java.util.*
 class UserService(private val nomisUserService: NomisUserService,
                   private val authUserService: AuthUserService,
                   private val deliusUserService: DeliusUserService,
+                  private val azureUserService: AzureUserService,
                   private val userRepository: UserRepository,
                   private val verifyEmailService: VerifyEmailService) {
 
@@ -29,6 +31,7 @@ class UserService(private val nomisUserService: NomisUserService,
   fun findMasterUserPersonDetails(username: String): Optional<UserPersonDetails> =
       authUserService.getAuthUserByUsername(username).map { UserPersonDetails::class.java.cast(it) }
           .or { nomisUserService.getNomisUserByUsername(username).map { UserPersonDetails::class.java.cast(it) } }
+          .or { azureUserService.getAzureUserByUsername(username).map { UserPersonDetails::class.java.cast(it) } }
           .or { deliusUserService.getDeliusUserByUsername(username).map { UserPersonDetails::class.java.cast(it) } }
 
   fun findUser(username: String): Optional<User> = userRepository.findByUsername(StringUtils.upperCase(username))

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/service/MfaService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/service/MfaService.kt
@@ -53,7 +53,7 @@ class MfaService(@Value("\${application.authentication.mfa.whitelist}") whitelis
   @Throws(MfaUnavailableException::class)
   fun createTokenAndSendMfaCode(username: String): MfaData {
     log.info("Creating token and sending email for {}", username)
-    val user = userService.getOrCreateUser(username)
+    val user = userService.getOrCreateUser(username).orElseThrow()
 
     val token = tokenService.createToken(TokenType.MFA, username)
     val code = tokenService.createToken(TokenType.MFA_CODE, username)

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/service/UserContextService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/service/UserContextService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.oauth2server.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.oauth2server.delius.service.DeliusUserService
 import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource
 import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource.azure
 import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource.delius
@@ -11,7 +12,9 @@ import uk.gov.justice.digital.hmpps.oauth2server.security.UserPersonDetails
 class UserMappingException(message: String): Exception(message)
 
 @Service
-class UserContextService {
+class UserContextService(
+    private val deliusUserService: DeliusUserService
+) {
   companion object {
     private val log = LoggerFactory.getLogger(UserContextService::class.java)
   }
@@ -33,7 +36,11 @@ class UserContextService {
     else -> throw UserMappingException("auth source '${from}' not supported")
   }
 
-  private fun mapFromAzure(username: String, to: AuthSource): UserPersonDetails? = when (to) {
+  private fun mapFromAzure(email: String, to: AuthSource): UserPersonDetails? = when (to) {
+    delius -> {
+      log.debug("mapping user context from azure -> delius")
+      deliusUserService.getDeliusUserByEmail(email)
+    }
     else -> throw UserMappingException("auth -> '${to}' mapping not supported")
   }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/service/UserContextService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/service/UserContextService.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.oauth2server.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource.azure
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource.delius
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource.fromNullableString
+import uk.gov.justice.digital.hmpps.oauth2server.security.UserPersonDetails
+
+class UserMappingException(message: String): Exception(message)
+
+@Service
+class UserContextService {
+  companion object {
+    private val log = LoggerFactory.getLogger(UserContextService::class.java)
+  }
+
+  private val deliusScope = "delius"
+
+  @Throws(UserMappingException::class)
+  fun resolveUser(loginUser: UserPersonDetails, scopes: Set<String>): UserPersonDetails {
+    if (scopes.contains(deliusScope)) {
+      return map(loginUser.username, fromNullableString(loginUser.authSource), delius) ?: loginUser
+    }
+
+    return loginUser
+  }
+
+  private fun map(username: String, from: AuthSource, to: AuthSource): UserPersonDetails? = when (from) {
+    to -> null
+    azure -> mapFromAzure(username, to)
+    else -> throw UserMappingException("auth source '${from}' not supported")
+  }
+
+  private fun mapFromAzure(username: String, to: AuthSource): UserPersonDetails? = when (to) {
+    else -> throw UserMappingException("auth -> '${to}' mapping not supported")
+  }
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/verify/TokenService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/verify/TokenService.kt
@@ -56,7 +56,7 @@ class TokenService(private val userTokenRepository: UserTokenRepository,
   @Transactional(transactionManager = "authTransactionManager")
   fun createToken(tokenType: TokenType, username: String): String {
     log.info("Requesting {} for {}", tokenType.description, username)
-    val user = userService.getOrCreateUser(username)
+    val user = userService.getOrCreateUser(username).orElseThrow()
     val userToken = user.createToken(tokenType)
     telemetryClient.trackEvent("${tokenType.description}Request",
         mapOf("username" to username), null)

--- a/src/main/resources/application-dev-config.yml
+++ b/src/main/resources/application-dev-config.yml
@@ -2,6 +2,23 @@ spring:
   h2:
     console:
       enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          microsoft:
+            client-id: dummy
+            client-secret: dummy
+            scope: openid,email,profile
+            authorization-grant-type: authorization_code
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+        provider:
+          microsoft:
+            authorization-uri: https://login.microsoftonline.com/0bb413d7-160d-4839-868a-f3d46537f6af/oauth2/v2.0/authorize
+            token-uri: https://login.microsoftonline.com/0bb413d7-160d-4839-868a-f3d46537f6af/oauth2/v2.0/token
+            user-info-uri: https://graph.microsoft.com/oidc/userinfo
+            user-name-attribute: sub
+            jwk-set-uri: https://login.microsoftonline.com/0bb413d7-160d-4839-868a-f3d46537f6af/discovery/v2.0/keys
 
 application:
   smoketest:
@@ -9,6 +26,7 @@ application:
 
   authentication:
     lockout-count: 3
+    show-azure-link: true
 
   # test key which doesn't send emails, but is automatically accepted by notify
   notify:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,6 +109,7 @@ application:
     mfa:
       whitelist: 172.16.0.0/12
       roles: ROLE_MFA
+    show-azure-link: false
 
 jwt:
   keystore:

--- a/src/main/resources/db/auth/V5_1__increase_username_length.sql
+++ b/src/main/resources/db/auth/V5_1__increase_username_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_retries ALTER COLUMN username TYPE varchar(240);
+ALTER TABLE users ALTER COLUMN username TYPE varchar(240);

--- a/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
+++ b/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
@@ -34,7 +34,9 @@ VALUES ('omicuser','1200','{"jwtFields":"-user_name"}','SYSTEM_READ_ONLY','passw
        ('delius-auth-api-client','3600', '{}','ROLE_AUTH_DELIUS_LDAP','client_credentials', null,'{bcrypt}$2a$10$OPvgbwhWDQ/yysDHfhzClO0ud2Q11fAIGt6n.dIW.v0wFFNW1Rnm.', null, null,'read', null),
        ('token-verification-auth-api-client','3600', '{}','ROLE_AUTH_TOKEN_VERIFICATION','client_credentials', null,'{bcrypt}$2a$10$hQPvQMNfbh2vhjTjDWHpoeN.iRFRddJJug6qtBkWzQ8uPEc53isZy', null, null,'read', null),
        ('v1-client','1200','{}','ROLE_NOMIS_API_V1,ROLE_BOOKING_CREATE,ROLE_BOOKING_RECALL,ROLE_GLOBAL_SEARCH','client_credentials',null,'$2a$10$r12DB/sqXduodnjtAY/ykO0S3KCySdVW4zhG3jlIRaIsfVkFOEds2',null,null,'read,write,proxy-user',null),
-       ('probation-offender-search-indexer-client','3600','{}','ROLE_PROBATION_INDEX,ROLE_COMMUNITY','client_credentials',null,'$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm',43200,null,'read',null);
+       ('probation-offender-search-indexer-client','3600','{}','ROLE_PROBATION_INDEX,ROLE_COMMUNITY','client_credentials',null,'$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm',43200,null,'read',null),
+       ('hmpps-ppm-client','3600','{}',null,'authorization_code','read,write','$2a$10$YRkR9FGSpZu3FAn5.Awtk.Yd0hg92y63VfVVAKhS6k66nMsc3/Hiy',43200,null,'read,write','http://localhost:3000/login/callback,http://localhost:3000'),
+       ('hmpps-ppm-system','3600','{}','ROLE_GLOBAL_SEARCH','client_credentials','read','$2a$10$YRkR9FGSpZu3FAn5.Awtk.Yd0hg92y63VfVVAKhS6k66nMsc3/Hiy',43200,null,'read',null);
 
 UPDATE oauth_client_details
 SET additional_information = '{"jwtFields":"-name"}'

--- a/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
+++ b/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
@@ -35,6 +35,7 @@ VALUES ('omicuser','1200','{"jwtFields":"-user_name"}','SYSTEM_READ_ONLY','passw
        ('token-verification-auth-api-client','3600', '{}','ROLE_AUTH_TOKEN_VERIFICATION','client_credentials', null,'{bcrypt}$2a$10$hQPvQMNfbh2vhjTjDWHpoeN.iRFRddJJug6qtBkWzQ8uPEc53isZy', null, null,'read', null),
        ('v1-client','1200','{}','ROLE_NOMIS_API_V1,ROLE_BOOKING_CREATE,ROLE_BOOKING_RECALL,ROLE_GLOBAL_SEARCH','client_credentials',null,'$2a$10$r12DB/sqXduodnjtAY/ykO0S3KCySdVW4zhG3jlIRaIsfVkFOEds2',null,null,'read,write,proxy-user',null),
        ('probation-offender-search-indexer-client','3600','{}','ROLE_PROBATION_INDEX,ROLE_COMMUNITY','client_credentials',null,'$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm',43200,null,'read',null),
+       ('delius-login-client','28800','{}','ROLE_ACCESS_DELIUS_ID,ROLE_COMMUNITY','authorization_code,refresh_token','read,delius','$2a$10$RYwV0QebHAovVXWPySb2lefr3HTDntGu1euXHDJc3zwh2NsqeNGHG','43200',null,'read,delius','http://localhost:5000/login/callback'),
        ('hmpps-ppm-client','3600','{}',null,'authorization_code','read,write','$2a$10$YRkR9FGSpZu3FAn5.Awtk.Yd0hg92y63VfVVAKhS6k66nMsc3/Hiy',43200,null,'read,write','http://localhost:3000/login/callback,http://localhost:3000'),
        ('hmpps-ppm-system','3600','{}','ROLE_GLOBAL_SEARCH','client_credentials','read','$2a$10$YRkR9FGSpZu3FAn5.Awtk.Yd0hg92y63VfVVAKhS6k66nMsc3/Hiy',43200,null,'read',null);
 

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -93,9 +93,12 @@
         </div>
       </div>
     </div>
-    <div class="govuk-form-group">
-      <input class="govuk-button" id="submit" type="submit" role="button" data-element-id="continue-button"
-             value="Sign in">
+    <div th:if="${@environment.getProperty('application.authentication.show-azure-link')}"  class="govuk-form-group">
+      <ul class="govuk-list">
+      <li><input class="govuk-button" id="submit" type="submit" role="button" data-element-id="continue-button"
+             value="Sign in"></li>
+        <li><a class="govuk-link" href="/auth/oauth2/authorization/microsoft">Log in with a Windows DOM1 account</a></li>
+      </ul>
     </div>
     <div class="govuk-form-group">
       <h2 class="govuk-heading-m">Problems signing in</h2>

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfigurationTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfigurationTest.kt
@@ -20,14 +20,17 @@ import uk.gov.justice.digital.hmpps.oauth2server.security.JwtAuthenticationSucce
 import uk.gov.justice.digital.hmpps.oauth2server.security.JwtCookieAuthenticationFilter
 import uk.gov.justice.digital.hmpps.oauth2server.security.LockingAuthenticationProvider
 import uk.gov.justice.digital.hmpps.oauth2server.security.NomisAuthenticationProvider
+import uk.gov.justice.digital.hmpps.oauth2server.security.OidcJwtAuthenticationSuccessHandler
 import uk.gov.justice.digital.hmpps.oauth2server.security.UserStateAuthenticationFailureHandler
 
 class AuthenticationManagerConfigurationTest {
   private val nomisUserDetailsService: AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> = mock()
   private val authUserDetailsService: AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> = mock()
   private val deliusUserDetailsService: AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> = mock()
+  private val azureUserDetailsService: AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> = mock()
   private val accessDeniedHandler: LoggingAccessDeniedHandler = mock()
   private val logoutSuccessHandler: RedirectingLogoutSuccessHandler = mock()
+  private val oidcJwtAuthenticationSuccessHandler: OidcJwtAuthenticationSuccessHandler = mock()
   private val jwtAuthenticationSuccessHandler: JwtAuthenticationSuccessHandler = mock()
   private val jwtCookieAuthenticationFilter: JwtCookieAuthenticationFilter = mock()
   private val jwtCookieName: String = "some cookie"
@@ -39,9 +42,8 @@ class AuthenticationManagerConfigurationTest {
   private val authenticationManagerBuilder: AuthenticationManagerBuilder = mock()
   private val clearAllSessionsLogoutHandler: ClearAllSessionsLogoutHandler = mock()
   private var authenticationManagerConfiguration = AuthenticationManagerConfiguration(nomisUserDetailsService, authUserDetailsService,
-      deliusUserDetailsService, accessDeniedHandler, logoutSuccessHandler, jwtAuthenticationSuccessHandler, jwtCookieAuthenticationFilter,
-      jwtCookieName, cookieRequestCache, authAuthenticationProvider, nomisAuthenticationProvider, deliusAuthenticationProvider,
-      userStateAuthenticationFailureHandle, clearAllSessionsLogoutHandler)
+      deliusUserDetailsService, azureUserDetailsService, accessDeniedHandler, logoutSuccessHandler, oidcJwtAuthenticationSuccessHandler, jwtAuthenticationSuccessHandler, jwtCookieAuthenticationFilter,
+      jwtCookieName, cookieRequestCache, authAuthenticationProvider, nomisAuthenticationProvider, deliusAuthenticationProvider, userStateAuthenticationFailureHandle, clearAllSessionsLogoutHandler)
 
   @Test
   fun configure_deliusProviderIsLast() {

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/JWTTokenEnhancerTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/JWTTokenEnhancerTest.kt
@@ -23,6 +23,8 @@ import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User
 import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource
 import uk.gov.justice.digital.hmpps.oauth2server.security.ExternalIdAuthenticationHelper
 import uk.gov.justice.digital.hmpps.oauth2server.security.UserDetailsImpl
+import uk.gov.justice.digital.hmpps.oauth2server.service.UserContextService
+import uk.gov.justice.digital.hmpps.oauth2server.service.UserMappingException
 import java.util.*
 
 internal class JWTTokenEnhancerTest {
@@ -30,11 +32,13 @@ internal class JWTTokenEnhancerTest {
   private val clientDetailsService: JdbcClientDetailsService = mock()
   private val externalIdAuthenticationHelper: ExternalIdAuthenticationHelper = mock()
   private val jwtTokenEnhancer = JWTTokenEnhancer()
+  private val userContextService: UserContextService = mock()
 
   @BeforeEach
   internal fun setUp() {
     ReflectionTestUtils.setField(jwtTokenEnhancer, "clientsDetailsService", clientDetailsService)
     ReflectionTestUtils.setField(jwtTokenEnhancer, "externalIdAuthenticationHelper", externalIdAuthenticationHelper)
+    ReflectionTestUtils.setField(jwtTokenEnhancer, "userContextService", userContextService)
   }
 
   @Test
@@ -44,6 +48,7 @@ internal class JWTTokenEnhancerTest {
     val uuid = UUID.randomUUID()
     val user = User.builder().id(uuid).username("user").source(AuthSource.auth).build()
     whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(user, "pass"))
+    whenever(userContextService.resolveUser(any(), any())).thenReturn(user)
     whenever(authentication.oAuth2Request).thenReturn(OAuth2Request(mapOf(), "client_id", listOf(), true, setOf(), setOf(), "redirect", setOf(), mapOf()))
     whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(createBaseClientDetails("+user_name,-name"))
     jwtTokenEnhancer.enhance(token, authentication)
@@ -61,6 +66,7 @@ internal class JWTTokenEnhancerTest {
     val uuid = UUID.randomUUID()
     val user = User.builder().id(uuid).username("user").person(Person("Joe", "bloggs")).source(AuthSource.auth).build()
     whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(user, "pass"))
+    whenever(userContextService.resolveUser(any(), any())).thenReturn(user)
     whenever(authentication.oAuth2Request).thenReturn(OAuth2Request(mapOf(), "client_id", listOf(), true, setOf(), setOf(), "redirect", setOf(), mapOf()))
     whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(createBaseClientDetails("-auth_source"))
     jwtTokenEnhancer.enhance(token, authentication)
@@ -78,6 +84,7 @@ internal class JWTTokenEnhancerTest {
     val uuid = UUID.randomUUID()
     val user = User.builder().id(uuid).username("user").person(Person("Joe", "bloggs")).source(AuthSource.auth).build()
     whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(user, "pass"))
+    whenever(userContextService.resolveUser(any(), any())).thenReturn(user)
     whenever(authentication.oAuth2Request).thenReturn(OAuth2Request(mapOf(), "client_id", listOf(), true, setOf(), setOf(), "redirect", setOf(), mapOf()))
     whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(BaseClientDetails())
     jwtTokenEnhancer.enhance(token, authentication)
@@ -99,7 +106,9 @@ internal class JWTTokenEnhancerTest {
   fun testEnhance_MissingAuthSource() {
     val token: OAuth2AccessToken = DefaultOAuth2AccessToken("value")
     whenever(authentication.isClientOnly).thenReturn(false)
-    whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(UserDetailsImpl("user", "name", emptyList(), "none", "userID", "jwtId"), "pass"))
+    val user = UserDetailsImpl("user", "name", emptyList(), "none", "userID", "jwtId")
+    whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(user, "pass"))
+    whenever(userContextService.resolveUser(any(), any())).thenReturn(user)
     whenever(authentication.oAuth2Request).thenReturn(OAuth2Request(mapOf(), "client_id", listOf(), true, setOf(), setOf(), "redirect", setOf(), mapOf()))
     whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(createBaseClientDetails("-name,+user_name"))
     jwtTokenEnhancer.enhance(token, authentication)
@@ -108,5 +117,45 @@ internal class JWTTokenEnhancerTest {
         entry("user_name", "user"),
         entry("auth_source", "none"),
         entry("user_id", "userID"))
+  }
+
+  @Test
+  fun `enhance modifies user info based on output from UserContextService`() {
+    val uuid = UUID.randomUUID()
+    val loginUser = User.builder().id(uuid).username("user").source(AuthSource.auth).build()
+    val deliusuuid = UUID.randomUUID()
+    val deliusUser = User.builder().id(deliusuuid).username("deliusUser").source(AuthSource.delius).build()
+    val token: OAuth2AccessToken = DefaultOAuth2AccessToken("value")
+
+    whenever(userContextService.resolveUser(any(), any())).thenReturn(deliusUser)
+    whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(loginUser, "pass"))
+    whenever(authentication.oAuth2Request).thenReturn(OAuth2Request(mapOf(), "client_id", listOf(), true, setOf(), setOf(), "redirect", setOf(), mapOf()))
+    whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(createBaseClientDetails("+user_name,-name"))
+
+    jwtTokenEnhancer.enhance(token, authentication)
+    assertThat(token.additionalInformation).containsOnly(
+        entry("sub", "deliusUser"),
+        entry("user_name", "deliusUser"),
+        entry("auth_source", "delius"),
+        entry("user_id", deliusuuid.toString()))
+  }
+
+  @Test
+  fun `getUser handles 'UserMappingException' and returns login user`() {
+    val uuid = UUID.randomUUID()
+    val user = User.builder().id(uuid).username("user").source(AuthSource.auth).build()
+    val token: OAuth2AccessToken = DefaultOAuth2AccessToken("value")
+
+    whenever(userContextService.resolveUser(any(), any())).thenThrow(UserMappingException::class.java)
+    whenever(authentication.userAuthentication).thenReturn(UsernamePasswordAuthenticationToken(user, "pass"))
+    whenever(authentication.oAuth2Request).thenReturn(OAuth2Request(mapOf(), "client_id", listOf(), true, setOf(), setOf(), "redirect", setOf(), mapOf()))
+    whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(createBaseClientDetails("+user_name,-name"))
+
+    jwtTokenEnhancer.enhance(token, authentication)
+    assertThat(token.additionalInformation).containsOnly(
+        entry("sub", "user"),
+        entry("user_name", "user"),
+        entry("auth_source", "auth"),
+        entry("user_id", uuid.toString()))
   }
 }

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/TrackingTokenServicesTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/TrackingTokenServicesTest.kt
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.web.client.RestTemplate
 import uk.gov.justice.digital.hmpps.oauth2server.security.ExternalIdAuthenticationHelper
 import uk.gov.justice.digital.hmpps.oauth2server.security.UserDetailsImpl
+import uk.gov.justice.digital.hmpps.oauth2server.service.UserContextService
 import uk.gov.justice.digital.hmpps.oauth2server.utils.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.oauth2server.utils.JwtAuthHelper.JwtParameters
 
@@ -43,6 +44,8 @@ internal class TrackingTokenServicesTest {
   private val tokenVerificationClientCredentials = TokenVerificationClientCredentials()
   private val tokenServices = TrackingTokenServices(telemetryClient, restTemplate, tokenVerificationClientCredentials, true)
   private val tokenServicesVerificationDisabled = TrackingTokenServices(telemetryClient, restTemplate, tokenVerificationClientCredentials, false)
+  private val userContextService: UserContextService = mock()
+
 
   @BeforeEach
   fun setUp() {
@@ -54,9 +57,10 @@ internal class TrackingTokenServicesTest {
     val tokenEnhancer = JWTTokenEnhancer()
     ReflectionTestUtils.setField(tokenEnhancer, "externalIdAuthenticationHelper", externalIdAuthenticationHelper)
     ReflectionTestUtils.setField(tokenEnhancer, "clientsDetailsService", clientDetailsService)
+    ReflectionTestUtils.setField(tokenEnhancer, "userContextService", userContextService)
     tokenServices.setTokenEnhancer(tokenEnhancer)
     tokenServicesVerificationDisabled.setTokenEnhancer(tokenEnhancer)
-
+    whenever(userContextService.resolveUser(any(), any())).thenReturn(USER_DETAILS);
     whenever(clientDetailsService.loadClientByClientId(any())).thenReturn(BaseClientDetails())
   }
 

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserControllerTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserControllerTest.kt
@@ -100,7 +100,7 @@ class UserControllerTest {
 
   @Test
   fun userEmail_found() {
-    whenever(userService.findUser(anyString())).thenReturn(Optional.of(User.builder().username("JOE").verified(true).email("someemail").build()))
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(User.builder().username("JOE").verified(true).email("someemail").build()))
     val responseEntity = userController.getUserEmail("joe")
     assertThat(responseEntity.statusCodeValue).isEqualTo(200)
     assertThat(responseEntity.body).isEqualTo(EmailAddress("JOE", "someemail"))
@@ -108,7 +108,7 @@ class UserControllerTest {
 
   @Test
   fun userEmail_notFound() {
-    whenever(userService.findUser(anyString())).thenReturn(Optional.empty())
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.empty())
     val responseEntity = userController.getUserEmail("joe")
     assertThat(responseEntity.statusCodeValue).isEqualTo(404)
     assertThat(responseEntity.body).isEqualTo(ErrorDetail("Not Found", "Account for username joe not found", "username"))
@@ -116,7 +116,7 @@ class UserControllerTest {
 
   @Test
   fun userEmail_notVerified() {
-    whenever(userService.findUser(anyString())).thenReturn(Optional.of(User.of("JOE")))
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(User.of("JOE")))
     val responseEntity = userController.getUserEmail("joe")
     assertThat(responseEntity.statusCodeValue).isEqualTo(204)
     assertThat(responseEntity.body).isNull()

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.oauth2server.auth.model.Contact
 import uk.gov.justice.digital.hmpps.oauth2server.auth.model.ContactType
 import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User
 import uk.gov.justice.digital.hmpps.oauth2server.auth.repository.UserRepository
+import uk.gov.justice.digital.hmpps.oauth2server.azure.service.AzureUserService
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.DeliusUserPersonDetails
 import uk.gov.justice.digital.hmpps.oauth2server.delius.service.DeliusUserService
 import uk.gov.justice.digital.hmpps.oauth2server.maintain.AuthUserService
@@ -28,9 +29,10 @@ class UserServiceTest {
   private val nomisUserService: NomisUserService = mock()
   private val authUserService: AuthUserService = mock()
   private val deliusUserService: DeliusUserService = mock()
+  private val azureUserService: AzureUserService = mock()
   private val userRepository: UserRepository = mock()
   private val verifyEmailService: VerifyEmailService = mock()
-  private val userService = UserService(nomisUserService, authUserService, deliusUserService, userRepository, verifyEmailService)
+  private val userService = UserService(nomisUserService, authUserService, deliusUserService, azureUserService, userRepository, verifyEmailService)
 
   @Nested
   inner class FindMasterUserPersonDetails {

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/service/MfaServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/service/MfaServiceTest.kt
@@ -157,7 +157,7 @@ class MfaServiceTest {
   @Test
   fun `createTokenAndSendMfaCode success`() {
     val user = User.builder().username("bob").person(Person("first", "last")).email("email").verified(true).build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -168,7 +168,7 @@ class MfaServiceTest {
   @Test
   fun `createTokenAndSendMfaCode by Email check email params`() {
     val user = User.builder().username("bob").person(Person("first", "last")).email("email").verified(true).build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -181,7 +181,7 @@ class MfaServiceTest {
   @Test
   fun `createTokenAndSendMfaCode by text check text params`() {
     val user = User.builder().username("bob").mobile("07700900321").mobileVerified(true).mfaPreference(MfaPreferenceType.TEXT).build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -200,7 +200,7 @@ class MfaServiceTest {
         .contacts(setOf(Contact(MOBILE_PHONE, "07700900321", false), (Contact(SECONDARY_EMAIL, "secondaryEmail", true))))
         .mfaPreference(MfaPreferenceType.SECONDARY_EMAIL)
         .build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -219,7 +219,7 @@ class MfaServiceTest {
         .contacts(setOf(Contact(MOBILE_PHONE, "07700900321", true), (Contact(SECONDARY_EMAIL, "secondaryEmail", true))))
         .mfaPreference(MfaPreferenceType.EMAIL)
         .build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -238,7 +238,7 @@ class MfaServiceTest {
         .contacts(setOf(Contact(MOBILE_PHONE, "07700900321", false), (Contact(SECONDARY_EMAIL, "secondaryEmail", true))))
         .mfaPreference(MfaPreferenceType.TEXT)
         .build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -257,7 +257,7 @@ class MfaServiceTest {
         .contacts(setOf(Contact(MOBILE_PHONE, "07700900321", true), (Contact(SECONDARY_EMAIL, "secondaryEmail", false))))
         .mfaPreference(MfaPreferenceType.SECONDARY_EMAIL)
         .build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))
@@ -270,7 +270,7 @@ class MfaServiceTest {
   @Test
   fun `createTokenAndSendMfaCode no valid preference`() {
     val user = User.builder().username("bob").build()
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     whenever(tokenService.createToken(eq(TokenType.MFA), anyString())).thenReturn("sometoken")
     whenever(tokenService.createToken(eq(TokenType.MFA_CODE), anyString())).thenReturn("somecode")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/service/UserContextServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/service/UserContextServiceTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.oauth2server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User
+import uk.gov.justice.digital.hmpps.oauth2server.delius.model.DeliusUserPersonDetails
+import uk.gov.justice.digital.hmpps.oauth2server.security.AuthSource.auth
+
+internal class UserContextServiceTest {
+  private val userContextService = UserContextService()
+
+  @Test
+  fun `resolveUser returns the same user for clients with 'normal' scopes`() {
+    val loginUser = User.builder().username("username").source(auth).build()
+
+    var scopes = setOf("read")
+    var user = userContextService.resolveUser(loginUser, scopes)
+    assertEquals(user, loginUser)
+
+    scopes = setOf("read", "write")
+    user = userContextService.resolveUser(loginUser, scopes)
+    assertEquals(user, loginUser)
+  }
+
+  @Test
+  fun `resolveUser attempts to map user for 'delius' scope but fails due to missing mapping implementation`() {
+    val loginUser = User.builder().username("username").source(auth).build()
+    val scopes = setOf("read", "delius")
+
+    assertThrows(UserMappingException::class.java) {
+      userContextService.resolveUser(loginUser, scopes)
+    }
+  }
+
+  @Test
+  fun `resolveUser returns the same user when attempting to map users to the same auth source`() {
+    val loginUser = DeliusUserPersonDetails("username", "id", "user", "name", "email@email.com")
+    val scopes = setOf("delius")
+
+    val user = userContextService.resolveUser(loginUser, scopes)
+    assertEquals(user, loginUser)
+  }
+}

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/TokenServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/TokenServiceTest.kt
@@ -101,7 +101,7 @@ class TokenServiceTest {
   @Test
   fun createToken() {
     val user = User.of("joe")
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     val token = tokenService.createToken(RESET, "token")
     assertThat(token).isNotNull()
     assertThat(user.tokens.map { it.token }).contains(token)
@@ -110,7 +110,7 @@ class TokenServiceTest {
   @Test
   fun `createToken check telemetry`() {
     val user = User.of("joe")
-    whenever(userService.getOrCreateUser(anyString())).thenReturn(user)
+    whenever(userService.getOrCreateUser(anyString())).thenReturn(Optional.of(user))
     tokenService.createToken(RESET, "token")
     verify(telemetryClient).trackEvent(eq("ResetPasswordRequest"), check {
       assertThat(it).containsOnly(entry("username", "token"))


### PR DESCRIPTION
this PR takes a minor step towards delius integration with HMPPS auth via azure AD by conditionally modifying the subject, username, auth_source and user_id claims if the "delius" scope is granted to the client. currently the code does nothing, since the only supported mapping is from "azure" auth source, and even that isn't implemented fully.

if you were to put this code in production, and a client managed to get successfully request the `delius` scope and logged in using auth or nomis credentials, you would see an error like this in the logs for each token request:

```
uk.gov.justice.digital.hmpps.oauth2server.service.UserMappingException: auth source 'auth' not supported
        at uk.gov.justice.digital.hmpps.oauth2server.service.UserMappingService.map(UserMappingService.kt:22)
        at uk.gov.justice.digital.hmpps.oauth2server.config.JWTTokenEnhancer.enhance(JWTTokenEnhancer.java:70)
        ...
```

see https://dsdmoj.atlassian.net/wiki/spaces/AC/pages/2210955287/ADR-003+Differentiate+User+IDs+in+HMPPS+Auth+Tokens for more background on why we are modifying the user details. 