### PR TITLE
DT-1110: 🗃🐛 Add unique constraint on user_token to prevent duplicates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   implementation("org.springframework.security:spring-security-jwt:1.1.1.RELEASE")
   implementation("org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE")
   implementation("io.jsonwebtoken:jjwt:0.9.1")
-  implementation("com.nimbusds:nimbus-jose-jwt:8.20")
+  implementation("com.nimbusds:nimbus-jose-jwt:9.0")
 
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
@@ -72,7 +72,7 @@ dependencies {
   testImplementation("org.slf4j:slf4j-api:1.7.30")
   testImplementation("com.auth0:java-jwt:3.10.3")
 
-  testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.18.1")
+  testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.19.0")
   testImplementation("org.fluentlenium:fluentlenium-junit-jupiter:4.5.1")
   testImplementation("org.fluentlenium:fluentlenium-assertj:4.5.1")
   testImplementation("io.swagger.parser.v3:swagger-parser-v2-converter:2.0.21")

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/auth/model/User.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/auth/model/User.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 
 import static javax.persistence.FetchType.EAGER;
 
+@SuppressWarnings("JpaDataSourceORMInspection")
 @Entity
 @Table(name = "USERS")
 @NoArgsConstructor
@@ -170,10 +171,15 @@ public class User implements UserPersonDetails, CredentialsContainer {
     }
 
     public UserToken createToken(final TokenType tokenType) {
-        final var token = new UserToken(tokenType, this);
-        // equals and hashcode by token type so remove will remove any token of same type
-        tokens.remove(token);
-        tokens.add(token);
+        final var optionalToken = tokens.stream().filter(t -> t.getTokenType() == tokenType).findFirst();
+        final UserToken token;
+        if (optionalToken.isPresent()) {
+            token = optionalToken.get();
+            token.resetExpiry();
+        } else {
+            token = new UserToken(tokenType, this);
+            tokens.add(token);
+        }
         return token;
     }
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/auth/model/UserToken.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/auth/model/UserToken.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 @Table(name = "USER_TOKEN")
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(of = {"tokenType"})
+@EqualsAndHashCode(of = {"user", "tokenType"})
 @ToString(exclude = "user")
 public class UserToken {
 
@@ -46,6 +46,10 @@ public class UserToken {
         this.tokenType = tokenType;
         this.user = user;
 
+        resetExpiry();
+    }
+
+    void resetExpiry() {
         final var now = LocalDateTime.now();
         this.tokenExpiry = tokenType == TokenType.CHANGE || tokenType == TokenType.MFA ? now.plusMinutes(20) : now.plusDays(1);
     }

--- a/src/main/resources/db/auth/V4_10__user_token_unique.sql
+++ b/src/main/resources/db/auth/V4_10__user_token_unique.sql
@@ -1,0 +1,7 @@
+delete
+from user_token
+where user_id in
+      (select user_id from user_token group by user_id, token_type having count(*) > 1);
+
+ALTER TABLE user_token
+    ADD CONSTRAINT user_token_user_id_token_type_uk UNIQUE (user_id, token_type);

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/ResetPasswordServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/ResetPasswordServiceTest.kt
@@ -135,7 +135,7 @@ class ResetPasswordServiceTest {
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(staffUserAccountForBobOptional)
     val existingUserToken = user.createToken(UserToken.TokenType.RESET)
     resetPasswordService.requestResetPassword("user", "url")
-    assertThat(user.tokens).hasSize(1).extracting<String> { obj: UserToken -> obj.token }.doesNotContain(existingUserToken.token)
+    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.containsExactly(existingUserToken.token)
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/VerifyEmailServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/VerifyEmailServiceTest.kt
@@ -80,7 +80,7 @@ class VerifyEmailServiceTest {
     whenever(userRepository.findByUsername(anyString())).thenReturn(Optional.of(user))
     whenever(referenceCodesService.isValidEmailDomain(anyString())).thenReturn(true)
     verifyEmailService.requestVerification("user", "email@john.com", "firstname", "full name", "url", User.EmailType.PRIMARY)
-    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.doesNotContain(existingUserToken.token)
+    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.containsExactly(existingUserToken.token)
   }
 
   @Test
@@ -90,7 +90,7 @@ class VerifyEmailServiceTest {
     whenever(userRepository.findByUsername(anyString())).thenReturn(Optional.of(user))
     whenever(referenceCodesService.isValidEmailDomain(anyString())).thenReturn(true)
     verifyEmailService.requestVerification("user", "email@john.com", "firstname", "full name", "url", User.EmailType.SECONDARY)
-    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.doesNotContain(existingUserToken.token)
+    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.containsExactly(existingUserToken.token)
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/verifyMobileServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/verifyMobileServiceTest.kt
@@ -75,7 +75,7 @@ class VerifyMobileServiceTest {
     val existingUserToken = user.createToken(TokenType.MOBILE)
     whenever(userRepository.findByUsername(anyString())).thenReturn(Optional.of(user))
     verifyMobileService.changeMobileAndRequestVerification("user", "07700900321")
-    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.doesNotContain(existingUserToken.token)
+    assertThat(user.tokens).hasSize(1).extracting<String> { it.token }.containsExactly(existingUserToken.token)
   }
 
   @Test


### PR DESCRIPTION
We're hydrating the user_token table into a Set so duplicates are automatically removed, so when we want to delete all the rows that doesn't work as the ones that were removed aren't processed so we get a foreign key violation.