### PR TITLE
AC-311 - Add links to login page for authenticating via OAuth2 clients

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/resource/LoginController.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/resource/LoginController.java
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.oauth2server.resource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,12 +13,26 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Controller
 public class LoginController {
+    final private List<ClientRegistration> clientRegistrations;
+
+    public LoginController(final Optional<InMemoryClientRegistrationRepository> clientRegistrationRepository) {
+        clientRegistrations = clientRegistrationRepository.map(registrations -> StreamSupport
+                .stream(registrations.spliterator(), false)
+                .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
     @GetMapping("/login")
     public ModelAndView loginPage(@RequestParam(required = false) final String error) {
-        final var modelAndView = new ModelAndView("login");
+        final var modelAndView = new ModelAndView("login", Collections.singletonMap("oauth2Clients", clientRegistrations));
         // send bad request if password wrong so that browser won't offer to save the password
         if (StringUtils.isNotBlank(error)) {
             modelAndView.setStatus(HttpStatus.BAD_REQUEST);

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -94,8 +94,13 @@
       </div>
     </div>
     <div class="govuk-form-group">
-      <input class="govuk-button" id="submit" type="submit" role="button" data-element-id="continue-button"
-             value="Sign in">
+      <ul class="govuk-list">
+        <li><input class="govuk-button" id="submit" type="submit" role="button" data-element-id="continue-button"
+                   value="Sign in"></li>
+        <li th:each="oauth2Client: ${oauth2Clients}">
+          <a class="govuk-link" th:id="${'oauth2-client-' + oauth2Client.clientName}" th:href="${'/auth/oauth2/authorization/' + oauth2Client.clientName}" th:text="${@environment.getProperty('application.authentication.' + oauth2Client.clientName + '.linktext')}">OAuth2 Client link text</a>
+        </li>
+      </ul>
     </div>
     <div class="govuk-form-group">
       <h2 class="govuk-heading-m">Problems signing in</h2>

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/resource/LoginControllerTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/resource/LoginControllerTest.kt
@@ -3,14 +3,21 @@ package uk.gov.justice.digital.hmpps.oauth2server.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import java.util.*
 
 class LoginControllerTest {
-  private val controller = LoginController()
+  private val clientRegistrationRepository: Optional<InMemoryClientRegistrationRepository> = Optional.empty()
+
+  private val controller = LoginController(clientRegistrationRepository)
   @Test
   fun loginPage_NoError() {
     val modelAndView = controller.loginPage(null)
     assertThat(modelAndView.viewName).isEqualTo("login")
     assertThat(modelAndView.status).isNull()
+    assertThat(modelAndView.modelMap["oauth2Clients"]).asList().isEmpty()
   }
 
   @Test
@@ -18,5 +25,28 @@ class LoginControllerTest {
     val modelAndView = controller.loginPage("bad")
     assertThat(modelAndView.viewName).isEqualTo("login")
     assertThat(modelAndView.status).isEqualTo(HttpStatus.BAD_REQUEST)
+    assertThat(modelAndView.modelMap["oauth2Clients"]).asList().isEmpty()
+  }
+
+  @Test
+  fun `login page shows links when OIDC clients are configured`() {
+    val clients = listOf(ClientRegistration
+        .withRegistrationId("test")
+        .clientName("Test")
+        .clientId("bd4de96a-437d-4fef-b1b2-5f4c1e39c080")
+        .redirectUriTemplate("{baseUrl}/login/oauth2/code/{registrationId}")
+        .authorizationUri("/test")
+        .tokenUri("/test")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .build())
+
+    val clientRegistrationRepository = Optional.of(InMemoryClientRegistrationRepository(clients))
+
+    val controller = LoginController(clientRegistrationRepository)
+
+    val modelAndView = controller.loginPage(null)
+    assertThat(modelAndView.viewName).isEqualTo("login")
+    assertThat(modelAndView.status).isNull()
+    assertThat(modelAndView.modelMap["oauth2Clients"]).asList().hasSize(1)
   }
 }


### PR DESCRIPTION
If OAuth2 clients are configured, show login links on the login page.

We only have a use case for 1 auth provider (Azure AD OIDC), but the code was simplified by making it show a link for each provider configured.

![image](https://user-images.githubusercontent.com/103082/94146645-2346ff80-fe6c-11ea-928a-5197b6804d84.png)
