### PR TITLE
AC-311 Add Azure AD documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,45 @@ the authorization header, which allows password, authorization_code and refresh 
 This will go to github to get the specified version of the front end toolkit.  Very noddy at present, so if the assets have changed at https://github.com/alphagov/govuk-frontend/tree/master/dist/assets/fonts for the specified version in question, then the list in the bash script will need updating to cope.
 
 It will sort out the css references to `/assets` as we run in a `/auth` context instead. 
+
+### Enabling Azure AD OIDC as an additional authentication provider
+
+It is possible to enable Azure AD as an external OIDC provider. This functionality is enabled by adding a client registration, detailed below.
+
+#### Prerequisites
+- Access to an Azure instance, and permissions to create app registrations. For development purposes we have been
+creating registrations on the `DEVL` Azure instance, which is operated by the PTTP team. 
+
+#### Creating an Azure app registration
+1. Navigate to the app registrations page https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps
+2. Create a new app registration. For "Supported account types", select: "Accounts in any organizational directory (Any Azure AD directory - Multitenant)". Set the redirect URL to `http://localhost:8080/auth/login/oauth2/code/microsoft`
+3. Save the registration. Note the Client ID and Directory ID.
+4. Navigate to the Certificates & Secrets tab, and add a new client secret, and note the secret value
+
+#### Configuring Auth
+Add the following configuration to HMPPS Auth, replacing the `<placeholders>` with real values from the Azure App registration
+```
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          microsoft: # This is used in the redirect-uri template below, so must match the redirect uri in Azure
+            client-id: <Client ID>
+            client-secret: <Client Secret>
+            scope: openid,email,profile
+            authorization-grant-type: authorization_code
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+        provider:
+          microsoft:
+            authorization-uri: https://login.microsoftonline.com/<Directory (tenant) ID>/oauth2/v2.0/authorize
+            token-uri: https://login.microsoftonline.com/<Directory (tenant) ID>/oauth2/v2.0/token
+            user-info-uri: https://graph.microsoft.com/oidc/userinfo
+            user-name-attribute: sub
+            jwk-set-uri: https://login.microsoftonline.com/<Directory (tenant) ID>/discovery/v2.0/keys
+
+application:
+  authentication:
+    microsoft: # Name must correspond with the registration above
+      linktext: Log in with a justice.gov.uk email
+```

--- a/README.md
+++ b/README.md
@@ -125,30 +125,10 @@ creating registrations on the `DEVL` Azure instance, which is operated by the PT
 3. Save the registration. Note the Client ID and Directory ID.
 4. Navigate to the Certificates & Secrets tab, and add a new client secret, and note the secret value
 
-#### Configuring Auth
-Add the following configuration to HMPPS Auth, replacing the `<placeholders>` with real values from the Azure App registration
+#### Configuring Auth to use Azure AD OIDC
+Set the active Spring profiles to additionally include the `azure-oidc` profile, then provide values for the following Spring properties:
 ```
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          microsoft: # This is used in the redirect-uri template below, so must match the redirect uri in Azure
-            client-id: <Client ID>
-            client-secret: <Client Secret>
-            scope: openid,email,profile
-            authorization-grant-type: authorization_code
-            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
-        provider:
-          microsoft:
-            authorization-uri: https://login.microsoftonline.com/<Directory (tenant) ID>/oauth2/v2.0/authorize
-            token-uri: https://login.microsoftonline.com/<Directory (tenant) ID>/oauth2/v2.0/token
-            user-info-uri: https://graph.microsoft.com/oidc/userinfo
-            user-name-attribute: sub
-            jwk-set-uri: https://login.microsoftonline.com/<Directory (tenant) ID>/discovery/v2.0/keys
-
-application:
-  authentication:
-    microsoft: # Name must correspond with the registration above
-      linktext: Log in with a justice.gov.uk email
-```
+auth.azureoidc.client_id=<client_id>
+auth.azureoidc.client_secret=<client_secret>
+auth.azureoidc.tenant_id=<tenant_id>
+``` 

--- a/src/main/resources/application-azure-oidc.yml
+++ b/src/main/resources/application-azure-oidc.yml
@@ -1,0 +1,23 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          microsoft:
+            client-id: ${auth.azureoidc.client_id}
+            client-secret: ${auth.azureoidc.client_secret}
+            scope: openid,email,profile
+            authorization-grant-type: authorization_code
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+        provider:
+          microsoft:
+            authorization-uri: https://login.microsoftonline.com/${auth.azureoidc.tenant_id}/oauth2/v2.0/authorize
+            token-uri: https://login.microsoftonline.com/${auth.azureoidc.tenant_id}/oauth2/v2.0/token
+            user-info-uri: https://graph.microsoft.com/oidc/userinfo
+            user-name-attribute: sub
+            jwk-set-uri: https://login.microsoftonline.com/${auth.azureoidc.tenant_id}/discovery/v2.0/keys
+
+application:
+  authentication:
+    microsoft:
+      linktext: Log in with a justice.gov.uk email


### PR DESCRIPTION
Open to the config being in an example yaml file rather than directly in the README.