### PR TITLE
DT-1290: flyway to update group_assignable_role so that role…

### DIFF
--- a/src/main/resources/db/auth/V5_01__pecs_person_author_role.sql
+++ b/src/main/resources/db/auth/V5_01__pecs_person_author_role.sql
@@ -1,0 +1,5 @@
+INSERT INTO group_assignable_role (role_id, group_id, automatic)
+select role_id, group_id, 1 from groups, roles
+where group_code like 'PECS_%'
+  and group_name not like 'PECS Court%'
+  and role_code = 'PECS_PER_AUTHOR'


### PR DESCRIPTION
…PECS_PER_AUTHOR is added to all pecs groups except PECS_COURT. When a new user is created and assigned a current PECS Group (except PECS Court ...) they will be assigned the PECS_PER_AUTHOR role