### PR TITLE
Dt 1293 empty auth roles fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/auth/model/Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/auth/model/Service.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.oauth2server.auth.model
 
+import org.apache.commons.lang3.StringUtils.trimToNull
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -18,7 +19,7 @@ data class Service(
   val description: String,
 
   @Column(name = "authorised_roles")
-  var authorisedRoles: String? = null,
+  private var authorisedRoles: String? = null,
 
   @Column(nullable = false)
   val url: String,
@@ -31,7 +32,7 @@ data class Service(
 ) {
 
   val roles: List<String>
-    get() = authorisedRoles?.split(',')?.map { it.trim() } ?: emptyList()
+    get() = authorisedRoles?.split(',')?.mapNotNull { trimToNull(it) } ?: emptyList()
 
   val isUrlInsteadOfEmail: Boolean
     get() = email?.startsWith("http") ?: false
@@ -39,6 +40,6 @@ data class Service(
   var authorisedRolesWithNewlines: String
     get() = authorisedRoles?.replace(",".toRegex(), "\n") ?: ""
     set(authorisedRolesWithNewlines) {
-      authorisedRoles = authorisedRolesWithNewlines.replace("\n".toRegex(), ",")
+      authorisedRoles = authorisedRolesWithNewlines.replace("\n".toRegex(), ",").split(',').mapNotNull { trimToNull(it) }.joinToString(",")
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesController.kt
@@ -46,9 +46,11 @@ class ServicesController(
     val userDetails = authentication.principal as UserPersonDetails
     val telemetryMap = mapOf("username" to userDetails.username, "code" to service.code)
     if (newService) {
+      replaceBlankAuthorisedRolesWithNull(service)
       authServicesService.addService(service)
       telemetryClient.trackEvent("AuthServiceDetailsAdd", telemetryMap, null)
     } else {
+      replaceBlankAuthorisedRolesWithNull(service)
       authServicesService.updateService(service)
       telemetryClient.trackEvent("AuthServiceDetailsUpdate", telemetryMap, null)
     }
@@ -63,5 +65,9 @@ class ServicesController(
     authServicesService.removeService(code)
     telemetryClient.trackEvent("AuthServiceDetailsDeleted", telemetryMap, null)
     return "redirect:/ui/services"
+  }
+
+  private fun replaceBlankAuthorisedRolesWithNull(service: Service) {
+    service.authorisedRoles = if (service.authorisedRoles.isNullOrBlank()) null else service.authorisedRoles
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesController.kt
@@ -46,11 +46,9 @@ class ServicesController(
     val userDetails = authentication.principal as UserPersonDetails
     val telemetryMap = mapOf("username" to userDetails.username, "code" to service.code)
     if (newService) {
-      replaceBlankAuthorisedRolesWithNull(service)
       authServicesService.addService(service)
       telemetryClient.trackEvent("AuthServiceDetailsAdd", telemetryMap, null)
     } else {
-      replaceBlankAuthorisedRolesWithNull(service)
       authServicesService.updateService(service)
       telemetryClient.trackEvent("AuthServiceDetailsUpdate", telemetryMap, null)
     }
@@ -65,9 +63,5 @@ class ServicesController(
     authServicesService.removeService(code)
     telemetryClient.trackEvent("AuthServiceDetailsDeleted", telemetryMap, null)
     return "redirect:/ui/services"
-  }
-
-  private fun replaceBlankAuthorisedRolesWithNull(service: Service) {
-    service.authorisedRoles = if (service.authorisedRoles.isNullOrBlank()) null else service.authorisedRoles
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/auth/model/ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/auth/model/ServiceTest.kt
@@ -11,13 +11,18 @@ class ServiceTest {
     @Test
     fun roles() {
       val service =
-        Service("CODE", "NAME", "Description", "SOME_ROLE, SOME_OTHER_ROLE", "http://some.url", true, "a@b.com")
+        Service("CODE", "NAME", "Description", "SOME_ROLE, , ,  SOME_OTHER_ROLE", "http://some.url", true, "a@b.com")
       assertThat(service.roles).containsExactly("SOME_ROLE", "SOME_OTHER_ROLE")
     }
 
     @Test
-    fun roles_empty() {
+    fun `authorisation roles is null`() {
       val service = Service("CODE", "NAME", "Description", null, "http://some.url", true, "a@b.com")
+      assertThat(service.roles).isEmpty()
+    }
+    @Test
+    fun `authorisation roles is an empty string`() {
+      val service = Service("CODE", "NAME", "Description", "", "http://some.url", true, "a@b.com")
       assertThat(service.roles).isEmpty()
     }
   }
@@ -41,14 +46,31 @@ class ServiceTest {
   inner class AuthorisedRolesWithNewlines {
     @Test
     fun authorisedRolesWithNewlines() {
-      val service = Service(code = "code", name = "", description = "", url = "")
-      service.authorisedRoles = "joe,bloggs,"
+      val service = Service(code = "code", name = "", description = "", url = "", authorisedRoles = "joe,bloggs,")
       assertThat(service.authorisedRolesWithNewlines).isEqualTo("joe\nbloggs\n")
     }
 
     @Test
     fun `authorisedRolesWithNewlines no roles`() {
       val service = Service(code = "code", name = "", description = "", url = "")
+      assertThat(service.authorisedRolesWithNewlines).isEqualTo("")
+    }
+  }
+
+  @Nested
+  inner class SetAuthorisedRolesWithNewlines {
+
+    @Test
+    fun authorisedRolesWithNewlines() {
+      val service = Service(code = "code", name = "", description = "", url = "")
+      service.authorisedRolesWithNewlines = "ROLE_PRISON_ADMIN \n \n ROLE_PRISON_ORG"
+      assertThat(service.authorisedRolesWithNewlines).isEqualTo("ROLE_PRISON_ADMIN\nROLE_PRISON_ORG")
+    }
+
+    @Test
+    fun `authorisedRolesWithNewlines no roles`() {
+      val service = Service(code = "code", name = "", description = "", url = "")
+      service.authorisedRolesWithNewlines = " \n \n "
       assertThat(service.authorisedRolesWithNewlines).isEqualTo("")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesControllerTest.kt
@@ -87,6 +87,19 @@ class ServicesControllerTest {
         null
       )
     }
+    @Test
+    fun `edit service - edit service blank authorised roles`() {
+      val service = Service(code = "editcode", name = "", description = "", url = "", authorisedRoles = "")
+      val url = controller.editService(authentication, service)
+      assertThat(url).isEqualTo("redirect:/ui/services")
+      assertThat(service.authorisedRoles).isNull()
+      verify(authServicesService).updateService(service)
+      verify(telemetryClient).trackEvent(
+        "AuthServiceDetailsUpdate",
+        mapOf("username" to "user", "code" to "editcode"),
+        null
+      )
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/ServicesControllerTest.kt
@@ -87,19 +87,6 @@ class ServicesControllerTest {
         null
       )
     }
-    @Test
-    fun `edit service - edit service blank authorised roles`() {
-      val service = Service(code = "editcode", name = "", description = "", url = "", authorisedRoles = "")
-      val url = controller.editService(authentication, service)
-      assertThat(url).isEqualTo("redirect:/ui/services")
-      assertThat(service.authorisedRoles).isNull()
-      verify(authServicesService).updateService(service)
-      verify(telemetryClient).trackEvent(
-        "AuthServiceDetailsUpdate",
-        mapOf("username" to "user", "code" to "editcode"),
-        null
-      )
-    }
   }
 
   @Nested


### PR DESCRIPTION
Dt 1293 fix for when authorisation roles are sent in as new lines or empty string