### PR TITLE
DT-1297 - Add app version and role name to app insights tracing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
 
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 ENV TZ=Europe/London
 RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
 

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -1,4 +1,7 @@
 {
+  "role": {
+    "name": "oauth2-server"
+  },
   "preview": {
     "processors": [
       {
@@ -32,6 +35,9 @@
         }
       }
     ]
+  },
+  "customDimensions": {
+    "application_Version": "${BUILD_NUMBER}"
   },
   "selfDiagnostics": {
     "destination": "console"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/config/VersionOutputter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/config/VersionOutputter.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.oauth2server.config
 
-import com.microsoft.applicationinsights.extensibility.ContextInitializer
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.boot.info.BuildProperties
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.EventListener
 
@@ -16,9 +14,6 @@ class VersionOutputter(buildProperties: BuildProperties) {
   fun logVersionOnStartup() {
     log.info("Version {} started", version)
   }
-
-  @Bean
-  fun versionContextInitializer() = ContextInitializer { it.component.setVersion(version) }
 
   companion object {
     private val log = LoggerFactory.getLogger(VersionOutputter::class.java)


### PR DESCRIPTION
The app version is now available as `customDimensions.application_Version`. vs `application_Version`. Not 100% happy with this but have not found a way to do this yet.