### PR TITLE
add ROLE_OASYS_READ_ONLY to local interventions client to allow use of offender-assessments-api

### DIFF
--- a/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
+++ b/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
@@ -49,7 +49,7 @@ VALUES ('omicuser','1200','{"jwtFields":"-user_name"}','SYSTEM_READ_ONLY','passw
        ('user-load','3600','{}','ROLE_MAINTAIN_OAUTH_USERS','client_credentials','read,write','{bcrypt}$2a$10$zF0guKjmvHPxmkGdqmPa9ehLM0myWx/KCYNvbpKb6.eEIsDlYc/5S',43200,null,'read,write',null),
        ('pecs-jpc-client','3600','{}',null,'authorization_code','read,write','$2a$10$YRkR9FGSpZu3FAn5.Awtk.Yd0hg92y63VfVVAKhS6k66nMsc3/Hiy',43200,null,'read,write','http://localhost:8080/login/oauth2/code/hmpps'),
        ('smoke-test-client','3600','{}','ROLE_SMOKE_TEST','client_credentials',null,'$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm',43200,null,'read',null),
-       ('interventions','1200','{}','ROLE_COMMUNITY,ROLE_AUTH_DELIUS_LDAP,ROLE_INTERVENTIONS','client_credentials,authorization_code,refresh_token', 'read,write', '$2a$10$a5WJN/AZc7Nq3rFoy5GOQ.avY.opPq/RaF59TXFaInt0Jxp6NV94a',43200,null,'read,write','http://localhost:3000,http://localhost:3000/login/callback');
+       ('interventions','1200','{}','ROLE_COMMUNITY,ROLE_AUTH_DELIUS_LDAP,ROLE_INTERVENTIONS,ROLE_OASYS_READ_ONLY','client_credentials,authorization_code,refresh_token', 'read,write', '$2a$10$a5WJN/AZc7Nq3rFoy5GOQ.avY.opPq/RaF59TXFaInt0Jxp6NV94a',43200,null,'read,write','http://localhost:3000,http://localhost:3000/login/callback');
 
 UPDATE oauth_client_details
 SET additional_information = '{"jwtFields":"-name"}'


### PR DESCRIPTION
small change to enable local dev using offender-assessments-api with the interventions client credentials.