### PR TITLE
✨ PPD-201: WIP - Matching NOMIS and Auth users by email

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/security/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/security/UserService.kt
@@ -173,6 +173,12 @@ class UserService(
         )
       }
   }
+
+  fun findUsersByEmail(email: String): List<UserPersonDetails> {
+    val authUsers = authUserService.findAuthUsersByEmail(email)
+    val nomisUsers = nomisUserService.getNomisUsersByEmail(email)
+    return (authUsers + nomisUsers).distinctBy { it.username }
+  }
 }
 
 data class PrisonUserDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserControllerIntTest.kt
@@ -75,6 +75,31 @@ class UserControllerIntTest : IntegrationTest() {
   }
 
   @Test
+  fun `User search endpoint returns user data for given email address`() {
+    webTestClient
+      .get().uri("/api/user?email=auth_user@digital.justice.gov.uk")
+      .headers(setAuthorisation("ITAG_USER"))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .json(
+        """
+       [{"username":"AUTH_USER","active":true,"name":"Auth Only","authSource":"auth","userId":"608955ae-52ed-44cc-884c-011597a77949"}]
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `User search endpoint returns empty`() {
+    webTestClient
+      .get().uri("/api/user?email=unknown@unknown.com")
+      .headers(setAuthorisation("ITAG_USER"))
+      .exchange()
+      .expectStatus().isNoContent
+      .expectBody().isEmpty
+  }
+
+  @Test
   fun `User username endpoint returns user data`() {
     webTestClient
       .get().uri("/api/user/RO_USER")
@@ -271,6 +296,14 @@ class UserControllerIntTest : IntegrationTest() {
   fun `User email endpoint not accessible without valid token`() {
     webTestClient
       .get().uri("/api/user/bob/email")
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  fun `User search endpoint not accessible without valid token`() {
+    webTestClient
+      .get().uri("/api/user?email=auth_user@digital.justice.gov.uk")
       .exchange()
       .expectStatus().isUnauthorized
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/resource/api/UserControllerTest.kt
@@ -198,6 +198,63 @@ class UserControllerTest {
     assertThat(responseEntity.body).isNull()
   }
 
+  @Test
+  fun userSearch_found() {
+    val user = createSampleUser("JOE")
+    whenever(userService.findUsersByEmail(anyString())).thenReturn(listOf(user))
+    val responseEntity = userController.getUsers("some@email.com")
+    assertThat(responseEntity.statusCodeValue).isEqualTo(200)
+    assertThat(responseEntity.body).isEqualTo(
+      listOf(
+        UserDetail(
+          "JOE",
+          true,
+          "Joe Bloggs",
+          AuthSource.auth,
+          null,
+          null,
+          USER_ID
+        )
+      )
+    )
+  }
+
+  @Test
+  fun userSearch_notFound() {
+    whenever(userService.findUsersByEmail(anyString())).thenReturn(emptyList())
+    val responseEntity = userController.getUsers("some@email.com")
+    assertThat(responseEntity.statusCodeValue).isEqualTo(204)
+    assertThat(responseEntity.body).isNull()
+  }
+
+  @Test
+  fun userSearch_badRequestIfEmailNull() {
+    whenever(userService.findUsersByEmail(anyString())).thenReturn(emptyList())
+    val responseEntity = userController.getUsers(null)
+    assertThat(responseEntity.statusCodeValue).isEqualTo(400)
+    assertThat(responseEntity.body).isEqualTo(
+      ErrorDetail(
+        "Bad Request",
+        "No email address provided to search",
+        "email"
+      )
+    )
+  }
+
+  @Test
+  fun userSearch_badRequestIfEmailEmpty() {
+    whenever(userService.findUsersByEmail(anyString())).thenReturn(emptyList())
+    val responseEntity = userController.getUsers("")
+    assertThat(responseEntity.statusCodeValue).isEqualTo(400)
+    assertThat(responseEntity.body).isEqualTo(
+      ErrorDetail(
+        "Bad Request",
+        "No email address provided to search",
+        "email"
+      )
+    )
+  }
+
   private fun setupFindUserCallForNomis(): NomisUserPersonDetails {
     val user = createSampleNomisUser(staff = Staff(firstName = "JOE", status = "INACTIVE", lastName = "bloggs", staffId = 5), username = "principal", accountStatus = "EXPIRED & LOCKED")
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(user))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/security/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/oauth2server/security/UserServiceTest.kt
@@ -229,6 +229,54 @@ class UserServiceTest {
   }
 
   @Nested
+  inner class FindUsersByEmail {
+    @Test
+    fun findUsersByEmail() {
+      val authUser = createSampleUser(username = "authuser")
+      val nomisUser = createSampleNomisUser(
+        staff = Staff(
+          firstName = "first",
+          lastName = "last",
+          status = "ACTIVE",
+          staffId = 123
+        ),
+        username = "nomisuser"
+      )
+
+      whenever(authUserService.findAuthUsersByEmail(anyString())).thenReturn(listOf(authUser))
+      whenever(nomisUserService.getNomisUsersByEmail(anyString())).thenReturn(listOf(nomisUser))
+
+      val found = userService.findUsersByEmail("some@email.com")
+
+      assertThat(found).hasSize(2)
+      assertThat(found[0]).isSameAs(authUser)
+      assertThat(found[1]).isSameAs(nomisUser)
+    }
+
+    @Test
+    fun findDistinctUsersByEmail() {
+      val authUser = createSampleUser(username = "user1")
+      val nomisUser = createSampleNomisUser(
+        staff = Staff(
+          firstName = "first",
+          lastName = "last",
+          status = "ACTIVE",
+          staffId = 123
+        ),
+        username = "user1"
+      )
+
+      whenever(authUserService.findAuthUsersByEmail(anyString())).thenReturn(listOf(authUser))
+      whenever(nomisUserService.getNomisUsersByEmail(anyString())).thenReturn(listOf(nomisUser))
+
+      val found = userService.findUsersByEmail("some@email.com")
+
+      assertThat(found).hasSize(1)
+      assertThat(found[0]).isSameAs(authUser)
+    }
+  }
+
+  @Nested
   inner class GetUser {
     @Test
     fun `getUser found`() {


### PR DESCRIPTION
There is not yet any way of searching for users across both
Auth and NOMIS based on their email address. This is work in
progress as we have need to search potentially by partial email
address and first / last names too.

Because this pulls data from two datasets, this just returns
a list (no pagination).