### PR TITLE
P4-2724 new PECS role for the journey price calculation service for maintenance of journey prices.

### DIFF
--- a/src/main/resources/db/auth/V5_29__add_pecs_price_maintenance_role.sql
+++ b/src/main/resources/db/auth/V5_29__add_pecs_price_maintenance_role.sql
@@ -1,0 +1,2 @@
+INSERT INTO roles (role_id, role_code, role_name)
+VALUES (newid(), 'PECS_MAINTAIN_PRICE', 'PECS Journey Price Maintenance');

--- a/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
+++ b/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql
@@ -290,6 +290,7 @@ VALUES
 ('ABD94E71-0047-43F1-842B-5BEF234AEB10', 'JPC_USER', '{bcrypt}$2a$10$Fmcp2KUKRW53US3EJfsxkOh.ekZhqz5.Baheb9E98QLwEFLb9csxy', 'auth.intel@digital.justice.gov.uk', 'JPC', 'User', 1, 0, 1, 0, '2020-05-01 15:07:34.5466667', '2040-04-26 16:17:28.4953990', '2020-05-18 14:16:21.7349800', 'auth', 'EMAIL');
 
 INSERT INTO user_role (role_id, user_id) SELECT role_id, user_id from roles, users where username = 'JPC_USER' and role_code = 'PECS_JPC';
+INSERT INTO user_role (role_id, user_id) SELECT role_id, user_id from roles, users where username = 'JPC_USER' and role_code = 'PECS_MAINTAIN_PRICE';
 
 -- auth user for interventions service provider journeys
 INSERT INTO users (user_id, username, password, email, first_name, last_name, verified, locked, enabled, master, create_datetime, password_expiry, last_logged_in, source, mfa_preference)


### PR DESCRIPTION
**Changes:**

This purpose of the role is to enable us to control which users can manage journey prices in the PECS Journey Price Calculation service. 