### PR TITLE
Add CRS provider role as a default to all CRS provider groups

### DIFF
--- a/src/main/resources/db/auth/V5_39__add_crs_role.sql
+++ b/src/main/resources/db/auth/V5_39__add_crs_role.sql
@@ -1,0 +1,7 @@
+INSERT INTO roles (role_id, role_code, role_name)
+VALUES (newid(), 'CRS_PROVIDER', 'Commissioned rehabilitative services (CRS) provider');
+
+INSERT INTO group_assignable_role (role_id, group_id, automatic)
+  SELECT role_id, g.group_id, 1
+  FROM roles r, groups g
+  WHERE r.role_code = 'CRS_PROVIDER' AND g.group_code LIKE 'INT_SP_%';


### PR DESCRIPTION
Default groups and roles for the dynamic framework (now called commissioned rehabilitative services) providers.

- Adds default role (`ROLE_CRS_PROVIDER`)
- Adds the role to all provider groups (previously applied manually) as a default role